### PR TITLE
Bump fa.js to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "fa.js": "^0.7.2"
+        "fa.js": "^0.7.3"
       },
       "devDependencies": {
         "@commander-js/extra-typings": "^12.1.0",
@@ -695,9 +695,10 @@
       }
     },
     "node_modules/fa.js": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/fa.js/-/fa.js-0.7.2.tgz",
-      "integrity": "sha512-rIdt/JUxJMO1XNR3U98p1gNrud4HcU3UOkS6wZPGiykjh7cYT7ZUVyVydf15Dbx8+DnIaYfIrhm9G1nU0IbSYA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fa.js/-/fa.js-0.7.3.tgz",
+      "integrity": "sha512-PXvoihDmSHvVTZiPN4D86aJ4rYLKfGh8YcGt6UOXsywBCOOqLjjLRda7MS01farpeKojAOrR+AwBiYH7IdrxoQ==",
+      "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",
         "date-fns": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
-    "fa.js": "^0.7.2"
+    "fa.js": "^0.7.3"
   }
 }


### PR DESCRIPTION
This adds support for exporting story-type submissions (see https://github.com/cheeplusplus/fa.js/pull/19).